### PR TITLE
Remove one flag from formatoptions at a time

### DIFF
--- a/after/ftplugin/smt.vim
+++ b/after/ftplugin/smt.vim
@@ -1,3 +1,3 @@
 setlocal comments=:;-
-setlocal formatoptions-=cro formatoptions+=j
+setlocal formatoptions-=c formatoptions-=r formatoptions-=o formatoptions+=j
 setlocal iskeyword+=-,:,#


### PR DESCRIPTION
See `:help remove-option-flags`. `setlocal formatoptions-=cro` searches 'formatoptions' for exact "cro", so "c", "r", or "o" flag won't be removed if 'formatoptions' is "cor", "cr", "ctro", etc.
